### PR TITLE
Update usage section to use src2png script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Install the [Fira Code](https://github.com/tonsky/FiraCode) font.
 ```sh
 yarn install
 brew install imagemagick  # trims image margins
-node src/camera.js YOUR_SOURCE_FILE [YOUR_SOURCE_FILE [...]]
+chown +x src2png
+./src2png YOUR_SOURCE_FILE [YOUR_SOURCE_FILE [...]]
 ls ./tmp  # screenshots are saved here
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Install the [Fira Code](https://github.com/tonsky/FiraCode) font.
 ```sh
 yarn install
 brew install imagemagick  # trims image margins
-chown +x src2png
 ./src2png YOUR_SOURCE_FILE [YOUR_SOURCE_FILE [...]]
 ls ./tmp  # screenshots are saved here
 ```


### PR DESCRIPTION
`src/camera.js` now just export `main` to be used in src2png script but the README still says `node src/camera.js`